### PR TITLE
Add confname attr

### DIFF
--- a/libraries/monit_check.rb
+++ b/libraries/monit_check.rb
@@ -34,6 +34,7 @@ class Chef::Resource
     attribute :tests, kind_of: Array, default: []
     attribute :every, kind_of: String
     attribute :alert, kind_of: String
+    attribute :confname, kind_of: String
 
     def check_type(arg = nil)
       set_or_return(
@@ -113,7 +114,8 @@ class Chef::Resource
         stop: stop, stop_as: stop_as, stop_as_group: stop_as_group,
         start_timeout: start_timeout, stop_timeout: stop_timeout,
         every: every, tests: tests, alert: alert, but_not_on: but_not_on,
-        alert_events: alert_events
+        alert_events: alert_events,
+        confname: confname
       }
     end
     # rubocop: enable AbcSize
@@ -165,7 +167,8 @@ class Chef::Provider
     private
 
     def tpl_path(resource)
-      ::File.join(node['monit']['conf_dir'], "#{resource.name}.conf")
+      name = resource.confname ? resource.confname : "#{resource.name}.conf"
+      ::File.join(node['monit']['conf_dir'], name)
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nath.e.will@gmail.com'
 license          'Apache 2.0'
 description      'Installs and configures monit'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.1'
+version          '2.2.2'
 
 %w( yum-epel ubuntu apt build-essential dpkg_autostart ).each do |dep|
   depends dep

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -27,6 +27,7 @@ template monit['conf_file'] do # ~FC009
     state_file: config['state_file'],
     mail_servers: config['mail_servers'],
     alert: config['alert'] || config['subscribers'],
+    confname: config['confname'],
     eventqueue_dir: config['eventqueue_dir'],
     eventqueue_slots: config['eventqueue_slots'],
     listen: config['listen'],


### PR DESCRIPTION
For some reason our code wants the name of the monit configuration file to be different than the name attribute of the monit_check resource :P
